### PR TITLE
Correct paths to compiled source

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "geostyler-cli",
   "version": "0.0.2",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "bin": {
-    "geostyler": "dist/index.js",
-    "geostyler-cli": "dist/index.js"
+    "geostyler": "dist/src/index.js",
+    "geostyler-cli": "dist/src/index.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "lint": "eslint . && tsc --noEmit --project tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Since 0c114af065092cad929437afe9b0fda1dcf05fae we use `resolveJsonModule` and import the `version`-field from the `package.json` file, which in turn leads to `tsc` copying over the folder structure, so that e.g. `src/index.ts` becomes `dist/src/index.js`.

This commit changes the references to the `dist/index.js` files so they match the new location `dist/src/index.js`.

Please review.