### PR TITLE
Read multiples files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,32 @@ npm uninstall -g geostyler-cli
 
 ## Syntax
 
+On a single file:
+
 ```
 geostyler [options] -o /path/to/output.ext /path/to/input.ext
 ```
 
+On a directory:
+
+```
+geostyler [options] -t qgis -o /path/to/output /path/to/input/
+```
+
 ## Options
 
-* `-o` / `--output` Output filename. Required.
-* `-s` / `--source` Source parser, either `mapbox`, `mapfile`, `sld` or `qgis`.
-If not given, it will be guessed from the extension of the input file.
-* `-t` / `--target` Target parser, either `mapbox`, `mapfile`, `sld` or `qgis`.
-If not given, it will be guessed from the extension of the output file.
 * `-h` / `--help` Display the help and exit.
+* `-o` / --output` Output filename or directory. Required. [string]
+* `-s` / `--source` Source parser, either `mapbox`, `mapfile` or `map`, `sld`,
+`qgis` or `qml`. If not given, it will be guessed from
+the extension of the input file. Mandatory if the the target
+is a directory.
+* `-t` / `--target` Target parser, either `mapbox`, `sld`,
+`qgis` or `qml`. If not given, it will be guessed from
+the extension of the output file. Mandatory if the the target
+is a directory.
+Mapfiles are currently not supported as target.
+* `-v` / --version` Display the version of the program.
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "geostyler-cli": "dist/src/index.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build-only": "tsc -p tsconfig.json",
+    "build": "npm run lint && npm run build-only",
     "start": "node dist/src/index.js",
     "lint": "eslint . && tsc --noEmit --project tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { logHelp, logVersion } from './logHelper';
 
 const ensureTrailingSlash = (inputString: string): string => {
   if (!inputString) {
-    return inputString;
+    return '';
   }
   return inputString[inputString.length - 1] === '/' ? inputString : `${inputString}/`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,18 @@ import QGISParser from 'geostyler-qgis-parser';
 // import OpenLayersParser from "geostyler-openlayers-parser";
 import MapfileParser from 'geostyler-mapfile-parser';
 import MapboxParser from 'geostyler-mapbox-parser';
-import { promises as fs } from 'fs';
+import { existsSync, lstatSync, promises, readdir } from 'fs';
 import minimist from 'minimist';
 import { StyleParser } from 'geostyler-style';
 import ora from 'ora';
 import { logHelp, logVersion } from './logHelper';
+
+const ensureTrailingSlash = (inputString: string): string => {
+  if (!inputString) {
+    return inputString;
+  }
+  return inputString[inputString.length - 1] === '/' ? inputString: `${inputString}/`;
+};
 
 const getParserFromFormat = (inputString: string): StyleParser => {
   if (!inputString) {
@@ -55,7 +62,87 @@ const getParserFromFilename = (fileName: string): StyleParser => {
   }
 };
 
+const getExtensionFromFormat = (format: string): string => {
+  if (!format) {
+    return '';
+  }
+  switch (format.toLowerCase()) {
+    case 'openlayers':
+    case 'ol':
+       return 'ts';
+    case 'mapfile':
+      return 'map';
+    case 'qgis':
+      return 'qml';
+    default:
+      return format;
+  }
+};
+
+const tryRemoveExtension = (fileName: string): string => {
+  const possibleExtensions = ['js', 'ts', 'mapbox', 'map', 'sld', 'qml'];
+  const splittedFileName = fileName.split('.');
+  const sourceFileExtension = splittedFileName.pop();
+  if (possibleExtensions.includes(sourceFileExtension.toLowerCase())) {
+    return splittedFileName.join('.');
+  }
+  return fileName;
+}
+
+const computeTargetPath = (
+  sourcePathFile: string,
+  outputPath: string,
+  targetIsFile: boolean,
+  targetFormat: string): string => {
+    if (targetIsFile) {
+      // Case file -> file
+      return outputPath;
+    }
+    // Case file -> directory
+    // Get output name from source and add extension.
+    const pathElements = sourcePathFile.split('/');
+    const targetFileName = tryRemoveExtension(pathElements.pop());
+    return `${ensureTrailingSlash(outputPath)}${targetFileName}.${getExtensionFromFormat(targetFormat)}`;
+};
+
+async function collectPaths(basePath: string, isFile: boolean): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    if (isFile) {
+      resolve([basePath]);
+    } else {
+      readdir(basePath, (error, files) => {
+        error ? reject(error) : resolve(files.map((file) =>`${ensureTrailingSlash(basePath)}${file}`));
+      });
+    }
+  });
+}
+
+async function writeFile(
+  sourceFile: string, sourceParser: StyleParser,
+  targetFile: string, targetParser: StyleParser,
+  indicator: any) {
+
+  const inputFileData = await promises.readFile(sourceFile, 'utf-8');
+
+  try {
+    indicator.text = `Reading from ${sourceFile}`;
+    const geostylerStyle = await sourceParser.readStyle(inputFileData);
+    indicator.text = `Writing to ${targetFile}`;
+    const targetStyle = await targetParser.writeStyle(geostylerStyle);
+    if (targetFile) {
+      await promises.writeFile(targetFile, targetStyle, 'utf-8');
+      indicator.succeed(`File "${sourceFile}" translated successfully. Output written to ${targetFile}`);
+    } else {
+      indicator.succeed(`File "${sourceFile}" translated successfully. Output written to stdout:\n`);
+      console.log(targetStyle);
+    }
+  } catch (error) {
+    indicator.fail(`Error during translation of file "${sourceFile}": ${error}`);
+  }
+};
+
 async function main() {
+  // Parse args
   const args = minimist(process.argv.slice(2));
   const {
     s,
@@ -81,22 +168,43 @@ async function main() {
     return;
   }
 
-  const sourceFile: string = unnamedArgs[0];
-  const sourceFormat: string = s || source;
+  // Assign args
+  const sourcePath: string = unnamedArgs[0];
+  const sourceFormat: string = s || sourcePath;
   const targetFormat: string = t || target;
-  const targetFile: string = o || output;
+  const outputPath: string = o || output;
 
+  // Instanciate progress indicator
   const indicator = ora('Starting Geostyler CLI').start();
 
-  if (!sourceFile) {
-    indicator.fail('No input file specified.');
+  // Check source path arg.
+  if (!sourcePath) {
+    indicator.fail('No input file or folder specified.');
     return;
   }
 
-  const sourceParser = getParserFromFormat(sourceFormat) || getParserFromFilename(sourceFile);
-  const targetParser = getParserFromFormat(targetFormat) || getParserFromFilename(targetFile);
-  const inputFileData = await fs.readFile(sourceFile, 'utf-8');
+  // Check source exists, is a dir or a file ?
+  if (!existsSync(sourcePath)) {
+    indicator.fail('Input file or folder does not exist.');
+  }
+  const sourceIsFile = lstatSync(sourcePath).isFile();
 
+  // Try to define type of target (file or dir).
+  let targetIsFile = true;
+  const outputExists = existsSync(outputPath);
+  if (outputExists) {
+    targetIsFile = lstatSync(outputPath).isFile();
+  }
+
+  // Dir to file is not possible
+  if (!sourceIsFile && (targetIsFile || !outputExists)) {
+    indicator.fail('The source is a directory, then the target must be an existing directory');
+    return;
+  }
+
+  // Get source and target parser.
+  const sourceParser = getParserFromFormat(sourceFormat) || (sourceIsFile && getParserFromFilename(sourcePath));
+  const targetParser = getParserFromFormat(targetFormat) || getParserFromFilename(outputPath);
   if (!sourceParser) {
     indicator.fail('No sourceparser was specified.');
     return;
@@ -106,23 +214,20 @@ async function main() {
     return;
   }
 
-  indicator.text = `Transforming file ${sourceFile} from ${sourceFormat} to ${targetFormat}`;
+  // Get source(s) path(s).
+  const sourcePaths = await collectPaths(sourcePath, sourceIsFile);
 
-  try {
-    indicator.text = `Reading from ${sourceFile}`;
-    const geostylerStyle = await sourceParser.readStyle(inputFileData);
-    indicator.text = `Writing to ${targetFile}`;
-    const targetStyle = await targetParser.writeStyle(geostylerStyle);
-    if (targetFile) {
-      await fs.writeFile(targetFile, targetStyle, 'utf-8');
-      indicator.succeed(`Output written to ${targetFile}`);
-    } else {
-      indicator.succeed('Output written to stdout:\n');
-      console.log(targetStyle);
+  const loopFn = async () => {
+    for (let i = 0; i < sourcePaths.length; i++) {
+      const srcPath = sourcePaths[i];
+      indicator.text = `Transforming ${srcPath} from ${sourceFormat} to ${targetFormat}`;
+      // Get correct output path
+      const outputPathFile = computeTargetPath(srcPath, outputPath, targetIsFile, targetFormat);
+      // Apply the translation.
+      await writeFile(srcPath, sourceParser, outputPathFile, targetParser, indicator);
     }
-  } catch (error) {
-    indicator.fail(`Error during translation: ${error}`);
   }
+  await loopFn();
 }
 
 main();

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -16,18 +16,24 @@ export const logHelp = () :void => {
   logTitle();
   console.log(`
   Basic syntax:
-    npx geostyler-cli [options] inputfile
-    npm start -- [options] inputfile
+    npx geostyler-cli [options] [input_file | [input_directory]]
+    npm start -- [options] [input_file | input_directory]
 
   Example:
     npx geostyler-cli -s sld -t qgis -o output.qml [YOUR_SLD.sld]
     npm start -- -s sld -t mapfile -o myStyle.map testdata/point_simplepoint.sld
 
   Options:
-    -s / --source : SourceParser. ["mapbox" | "mapfile" | "sld" | "qgis"]
-    -t / --target : TargetParser. ["mapbox" | "mapfile" | "sld" | "qgis"]
-    -o / --output : Output filename. [string]
-    -h / --help: Display this help.
+    -h / --help   : Display this help.
+    -o / --output : Output filename or directory. Required. [string]
+    -s / --source : SourceParser, either "mapbox", "mapfile" or "map", "sld",
+                    "qgis" or "qml". If not given, it will be guessed from the
+                    extension of the output file. Mandatory if the the target
+                    is a directory.
+    -t / --target : Target parser, either "mapbox", "mapfile" or "map", "sld",
+                    "qgis" or "qml". If not given, it will be guessed from the
+                    extension of the output file. Mandatory if the the target
+                    is a directory. Mapfiles are currently not supported as target.
     -v / --version: Display the version of the program.
   `);
 };


### PR DESCRIPTION
Hi,

In the scope of the development of the `geostyler-mapfile-parser` project, we would like to be able to parse multiple files in a folder at once and write every transformed file in another directory.

I've added this possibility in this `geostyler-cli` tool.

Now it's possible to:
 - (Read one file to write it to one file => was already possible).
 - Read one file to write it to a directory.
 - Read a directory to write results to a directory.

Trying to read a directory to write it to one file will throw an error.

---

I added a second commit to `run npm lint` directly with `npm run build` (I don't like to use `pre` rules, like `prebuild`, but I can use it if you want).

---

**To test, you will need #9**