### PR TITLE
Allow raw GeoStyler output option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ async function main() {
     return;
   }
   if (!targetParser) {
-    indicator.info('No targetparser was specified. Output will be a Geostyler object.');
+    indicator.info('No targetparser was specified. Output will be a GeoStyler object.');
   }
 
   // Get source(s) path(s).

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ async function collectPaths(basePath: string, isFile: boolean): Promise<string[]
 
 async function writeFile(
   sourceFile: string, sourceParser: StyleParser,
-  targetFile: string, targetParser: StyleParser,
+  targetFile: string, targetParser: StyleParser | undefined,
   oraIndicator: Ora
 ) {
   const inputFileData = await promises.readFile(sourceFile, 'utf-8');
@@ -146,7 +146,7 @@ async function writeFile(
     indicator.text = `Reading from ${sourceFile}`;
     const geostylerStyle = await sourceParser.readStyle(inputFileData);
     indicator.text = `Writing to ${targetFile}`;
-    const targetStyle = await targetParser.writeStyle(geostylerStyle);
+    const targetStyle = targetParser ? await targetParser.writeStyle(geostylerStyle) : JSON.stringify(geostylerStyle);
     if (targetFile) {
       await promises.writeFile(targetFile, targetStyle, 'utf-8');
       indicator.succeed(`File "${sourceFile}" translated successfully. Output written to ${targetFile}`);
@@ -229,8 +229,7 @@ async function main() {
     return;
   }
   if (!targetParser) {
-    indicator.fail('No targetparser was specified.');
-    return;
+    indicator.info('No targetparser was specified. Output will be a Geostyler object.');
   }
 
   // Get source(s) path(s).

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -36,6 +36,7 @@ export const logHelp = () :void => {
                     "qgis" or "qml". If not given, it will be guessed from the
                     extension of the output file. Mandatory if the the target
                     is a directory. Mapfiles are currently not supported as target.
+                    If not set GeoStyler objects will be output as JSON.
     -v / --version: Display the version of the program.
   `);
 };

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -25,7 +25,9 @@ export const logHelp = () :void => {
 
   Options:
     -h / --help   : Display this help.
-    -o / --output : Output filename or directory. Required. [string]
+    -o / --output : Output filename or directory. Mandatory if the target
+                    is a directory. If not provided for a single file then output
+                    will be written to stdout. [string]
     -s / --source : SourceParser, either "mapbox", "mapfile" or "map", "sld",
                     "qgis" or "qml". If not given, it will be guessed from the
                     extension of the output file. Mandatory if the the target

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -32,11 +32,11 @@ export const logHelp = () :void => {
                     "qgis" or "qml". If not given, it will be guessed from the
                     extension of the output file. Mandatory if the the target
                     is a directory.
-    -t / --target : Target parser, either "mapbox", "mapfile" or "map", "sld",
-                    "qgis" or "qml". If not given, it will be guessed from the
-                    extension of the output file. Mandatory if the the target
-                    is a directory. Mapfiles are currently not supported as target.
-                    If not set GeoStyler objects will be output as JSON.
+    -t / --target : Target parser, either "mapbox", "sld", "qgis" or "qml".
+                    Mapfiles are currently not supported as target.
+                    Mandatory if the the target is a directory. If not given and cannot
+                    be guessed from the extension of the output file, the output will
+                    default to GeoStyler objects represented as JSON.
     -v / --version: Display the version of the program.
   `);
 };


### PR DESCRIPTION
This pull request allows the command-line application to output raw GeoStyler objects from input files, without converting to another format. It is set to the default if no `--target` is specified, and the output cannot be determined based on file extension. 

The use case is to allow other programs or scripts to take advantage of the intermediary GeoStyler format and allow custom conversions directly on the JSON without requiring a new GeoStyler parser. In my particular use case it is to convert the GeoStyler format to a MapServer Mapfile output using Python and [mappyfile](https://github.com/geographika/mappyfile/). 

If this is an unwanted feature please feel free to close this pull request, or let me know if there are any required changes to be made. 

Also a minor update to the `--help` text as the `--output` can be dropped if you want to see the output on `stdout` (currently it is documented as mandatory). 