### PR TITLE
Fix file output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,10 +269,10 @@ async function main() {
   const sourceIsFile = lstatSync(sourcePath).isFile();
 
   // Try to define type of target (file or dir).
-  let targetIsFile = false;
+  let targetIsFile = true;
   const outputExists = existsSync(outputPath);
-  if (outputExists) {
-    targetIsFile = lstatSync(outputPath).isFile();
+  if (outputExists && lstatSync(outputPath).isDirectory()) {
+    targetIsFile = false;
   }
 
   // Dir to file is not possible


### PR DESCRIPTION
Attempt to fix #344
This requires a (root) output folder to already exist when outputting to a folder. Without additional parameters there is no consistent way to tell if a string is a folder or a file across multiple OSs. 