### PR TITLE
Fix folder output when processing multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ You can then use the new `geostyler` command, e.g.:
 geostyler -s sld -t qgis -o output.qml input.sld
 ```
 
+To process a folder of files:
+
+```
+geostyler -s sld -t qgis -o /outputdir /inputdir
+```
+
+
 ### Update 🚀
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-cli",
-  "version": "2.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "dist/src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-cli",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "",
   "main": "dist/src/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ const computeTargetPath = (
   const lastElement = pathElements?.pop();
   pathElements.shift();
 
-  const finalPathElements = [outputPath, pathElements];
+  const finalPathElements = [outputPath, pathElements].flat();
   const finalPath = finalPathElements.join(path.sep);
 
   if (typeof lastElement) {
@@ -269,11 +269,9 @@ async function main() {
   const sourceIsFile = lstatSync(sourcePath).isFile();
 
   // Try to define type of target (file or dir).
-  let targetIsFile = false;
+  // Assume the target is the same as the source
+  let targetIsFile = sourceIsFile;
   const outputExists = existsSync(outputPath);
-  if (outputExists) {
-    targetIsFile = lstatSync(outputPath).isFile();
-  }
 
   // Dir to file is not possible
   if (!sourceIsFile && targetIsFile) {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const { spawnSync } = require('child_process');
 
 function checkFileCreated(outputFile) {
   try {
-    fs.accessSync(path, fs.constants.F_OK);
+    fs.accessSync(outputFile, fs.constants.F_OK);
     return true;
   } catch (err) {
     /* eslint-disable no-console */
@@ -19,8 +19,6 @@ function runTest(args, outputFile) {
   console.log(`Status: ${result.status.toString()}`);
   console.log(`Output: ${result.stdout.toString()}`);
   console.log(`Error: ${result.stderr.toString()}`);
-
-  return checkFileCreated(outputFile);
 }
 
 function runAllTests() {
@@ -30,24 +28,39 @@ function runAllTests() {
   // test sld to qgis
   let outputFile = 'output.qml';
   let args = ['start', '--', '-s', 'sld', '-t', 'qgis', '-o', outputFile, 'testdata/point_simplepoint.sld'];
+  runTest(args, outputFile);
 
-  if (runTest(args, outputFile) === false) {
+  if (checkFileCreated(outputFile) === false) {
     success = false;
   }
 
   // test qgis to sld
   outputFile = 'output.sld';
   args = ['start', '--', '-s', 'qgis', '-t', 'sld', '-o', outputFile, 'testdata/point_simple.qml'];
+  runTest(args, outputFile);
 
-  if (runTest(args, outputFile) === false) {
+  if (checkFileCreated(outputFile) === false) {
     success = false;
   }
 
   // test mapfile to geostyler
   outputFile = 'output.map';
   args = ['start', '--', '-s', 'mapfile', '-o', outputFile, 'testdata/point_simplepoint.map'];
+  runTest(args, outputFile);
 
-  if (runTest(args, outputFile) === false) {
+  if (checkFileCreated(outputFile) === false) {
+    success = false;
+  }
+
+  // test folder output
+  args = ['start', '--', '-s', 'sld', '-t', 'qgis', '-o', './output', 'testdata'];
+  runTest(args, outputFile);
+
+  if (checkFileCreated('./output/point_simplepoint.qml') === false) {
+    success = false;
+  }
+
+  if (checkFileCreated('./output/point_simpletriangle.qml') === false) {
     success = false;
   }
 

--- a/testdata/point_simpletriangle.sld
+++ b/testdata/point_simpletriangle.sld
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Triangle</Name>
+    <UserStyle>
+      <Title>Simple Triangle</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill-opacity">0.5</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#0000FF</CssParameter>
+                  <CssParameter name="stroke-opacity">0.7</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Fix for #343. The main issue was the array was not flattened which meant output paths when processing a directory ended up looking like `mypath/dir1,dir2,fiename.json`. Adding `flat()` fixes this. 

Pull request:

- also bumps version as the is currently does not match the npm version number
- adds tests for the directory processing
- adds an additional sld file to test processing multiple files
- adds a note the the ReadMe