### PR TITLE
docs: ensure consistency between README and program help. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,33 +70,50 @@ npm uninstall -g geostyler-cli
 ```
 
 
-## Syntax
+## Syntax and examples
 
-On a single file:
+To convert a single file:
 
-```
+```bash
 geostyler [options] -o /path/to/output.ext /path/to/input.ext
+# example, relying on file extensions to select the parsers
+geostyler -o point_simple.sld testdata/point_simple.qml
+# example with explicit parsers
+geostyler -s qml -t sld -o point_simple.sld testdata/point_simple.qml
 ```
 
-On a directory:
+To convert all files in a directory:
 
-```
+```bash
 geostyler [options] -t qgis -o /path/to/output /path/to/input/
+# example
+geostyler -s sld -t qgis -o ./output-sld testdata/sld
+```
+
+To output the GeoStyler format to `stdout` (only available for a single file), don't
+set an output file or parser:
+
+```bash
+geostyler [options] /path/to/input.ext
+# print the GeoStyler format to stdout (relying on the file extension to select the parser)
+geostyler testdata/point_simple.qml
+# print an SLD output to stdout
+geostyler -t sld testdata/point_simple.qml
 ```
 
 ## Options
 
 * `-h` / `--help` Display the help and exit.
-* `-o` / `--output` Output filename or directory. Required. [string]
-* `-s` / `--source` Source parser, either `mapbox`, `mapfile` or `map`, `sld` (for SLD 1.0), `se` (for SLD 1.1),
-`qgis` or `qml`. If not given, it will be guessed from
-the extension of the input file. Mandatory if the the target
-is a directory.
+* `-o` / `--output` Output filename or directory. Required when the source is a directory.
+For a file leave this empty to write to `stdout`. [string]
+* `-s` / `--source` Source parser, either `mapbox`, `mapfile` or `map`, 
+`sld` or `se` for SLD - the parser will read the version from the file,
+and `qgis` or `qml` for QGIS QML files. If not given, it will be guessed from the extension of the input file. 
+Mandatory if the the target is a directory.
 * `-t` / `--target` Target parser, either `mapbox`, `sld` (for SLD 1.0), `se` (for SLD 1.1),
 and `qgis` or `qml` for QGIS QML files. If not given, it will be guessed from
-the extension of the output file. Mandatory if the the target
-is a directory.
-Mapfiles are currently not supported as target.
+the extension of the output file. Mapfiles are not currently supported as target.
+Mandatory if the the target is a directory.
 * `-v` / `--version` Display the version of the program.
 
 ## Developing

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -17,26 +17,26 @@ export const logHelp = () :void => {
   console.log(`
   Basic syntax:
     npx geostyler-cli [options] [input_file | [input_directory]]
-    npm start -- [options] [input_file | input_directory]
+    geostyler [options] [input_file | input_directory]
 
   Example:
     npx geostyler-cli -s sld -t qgis -o output.qml [YOUR_SLD.sld]
-    npm start -- -s sld -t mapfile -o myStyle.map testdata/point_simplepoint.sld
-
+    geostyler -s qml -t mapfile -o myStyle.map testdata/point_simple.qml
+    geostyler -s sld -t qgis -o ./output-sld testdata/sld
+    
   Options:
-    -h / --help   : Display this help.
-    -o / --output : Output filename or directory. Mandatory if the target
-                    is a directory. If not provided for a single file then output
-                    will be written to stdout. [string]
-    -s / --source : SourceParser, either "mapbox", "mapfile" or "map", "sld",
-                    "qgis" or "qml". If not given, it will be guessed from the
-                    extension of the output file. Mandatory if the the target
-                    is a directory.
-    -t / --target : Target parser, either "mapbox", "sld", "qgis" or "qml".
-                    Mapfiles are currently not supported as target.
-                    Mandatory if the the target is a directory. If not given and cannot
-                    be guessed from the extension of the output file, the output will
-                    default to GeoStyler objects represented as JSON.
+    -h / --help   : Display this help and exit.
+    -o / --output : Output filename or directory. Required when the source is a directory.
+                    For a file leave this empty to write to stdout. [string]
+    -s / --source : Source parser, either "mapbox", "mapfile" or "map", 
+                    "sld" or "se" for SLD - the parser will read the version from the file,
+                    and "qgis" or "qml" for QGIS QML files. If not given, it will be guessed from the extension of the input file. 
+                    Mandatory if the the target is a directory.
+    -t / --target : Target parser, either "mapbox", "sld" (for SLD 1.0), "se" (for SLD 1.1),
+                    and "qgis" or "qml" for QGIS QML files. 
+                    If not given, it will be guessed from the extension of the output file. 
+                    Mapfiles are not currently supported as target.
+                    Mandatory if the the target is a directory.
     -v / --version: Display the version of the program.
   `);
 };


### PR DESCRIPTION
Also add note about SLD export versions. Add additional usage examples.