### PR TITLE
style: avoid lint errors with no-console

### DIFF
--- a/package-binaries.js
+++ b/package-binaries.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
 const AdmZip = require('adm-zip');


### PR DESCRIPTION
Avoid the following CI failures when eslint is updated:

```
/home/runner/work/geostyler-cli/geostyler-cli/package-binaries.js
Warning:   42:7  warning  Unexpected console statement  no-console
Warning:   45:5  warning  Unexpected console statement  no-console
Warning:   47:5  warning  Unexpected console statement  no-console
```