### PR TITLE
Stringify objects before writing file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ async function writeFile(
           console.log(`Target parser ${targetParser.title} does not support the following properties:`);
           console.log(writeUnsupportedProperties);
         }
-        output = writeOutput;
+        output = typeof writeOutput === 'object' ? JSON.stringify(writeOutput, undefined, 2) : writeOutput;
       } else {
         output = JSON.stringify(readOutput, undefined, 2);
       }


### PR DESCRIPTION
This pull request fixes outputting mapbox style files, e.g. when running

    npx geostyler-cli -s sld -t mapbox --output out.json in.sld