### PR TITLE
Fix file extension logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const getParserFromFilename = (fileName: string): StyleParser | undefined => {
   if (!fileName) {
     return undefined;
   }
-  const fileEnding = fileName.split('.')[1];
+  const fileEnding = fileName.split('.').pop();
   if (!fileEnding) {
     return undefined;
   }


### PR DESCRIPTION
A file's extension is the part after the last dot, not the first dot
otherwise common filenames like `../data/example.qml` won't work.