### PR TITLE
feat: add geostyler style as a format

### DIFF
--- a/test.js
+++ b/test.js
@@ -52,6 +52,15 @@ function runAllTests() {
     success = false;
   }
 
+  // test geostyler to mapbox
+  outputFile = 'output.mapbox';
+  args = ['start', '--', '-s', 'geostyler', '-o', outputFile, 'testdata/point_simplepoint.geostyler'];
+  runTest(args, outputFile);
+
+  if (checkFileCreated(outputFile) === false) {
+    success = false;
+  }
+
   // test folder output
   args = ['start', '--', '-s', 'sld', '-t', 'qgis', '-o', './output-bulk', 'testdata/sld'];
   runTest(args, outputFile);


### PR DESCRIPTION
Adds geostyler as a format, such that 
```
input.geostyler
-s geostyler
-t geostyler
-o output.geostyler
```
all work.

Tidies up some logic around selecting formats - we don't want to warn the user that no format was specified if they explicitly specified "geostyler"

Removes some duplicated code
- instantiation of parsers
- handling of parser errors

Fixes #392 