### PR TITLE
feat: add converter for sld with GeoServer VendorOption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ const getParserFromFormat = (inputString: string): StyleParser | undefined => {
       return new SLDParser();
     case 'se':
       return new SLDParser({sldVersion:'1.1.0'});
+    case 'sld-gsvo':
+      return new SLDParser({withGeoServerVendorOption:true});
     case 'qgis':
     case 'qml':
       return new QGISParser();


### PR DESCRIPTION
For #427 Add a format for SLD with enabled GeoServerVendorOption.

Is there a doc to update somewhere ? I understand that `sld-gsvo` is not the most understandable name.