### PR TITLE
docs: remove ol-flat from list of target parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For a file leave this empty to write to `stdout`. [string]
 If not given, it will be guessed from the extension of the input file.
 Mandatory if the target is a directory.
 * `-t` / `--target` Target parser, either `mapbox`, `sld`,
-`qgis` or `qml` for QGIS QML files, or `ol-flat` for OpenLayers FlatStyles.
+`qgis` or `qml` for QGIS QML files.
 If not given, it will be guessed from the extension of the output file.
 Mapfiles are not currently supported as target.
 Mandatory if the target is a directory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ async function writeFile(
   if (targetParser instanceof MapfileParser) {
     throw new Error('MapfileParser is not supported as target parser.');
   }
+  if (targetParser instanceof OlFlatStyleParser) {
+    throw new Error('OlFlatStyleParser is not supported as target parser.');
+  }
   const indicator = oraIndicator; // for linter.
 
   try {

--- a/src/logHelper.ts
+++ b/src/logHelper.ts
@@ -34,7 +34,7 @@ export const logHelp = (): void => {
                      If not given, it will be guessed from the extension of the input file.
                      Mandatory if the the target is a directory.
     -t / --target  : Target parser, either "mapbox", "sld",
-                     "qgis" or "qml" for QGIS QML files, or "ol-flat" for OpenLayers FlatStyles.
+                     "qgis" or "qml" for QGIS QML files.
                      If not given, it will be guessed from the extension of the output file.
                      Mapfiles are not currently supported as target.
                      Mandatory if the the target is a directory.


### PR DESCRIPTION
This removes the ol-flat option from the list of target parsers, since writing ol-flat styles is not yet implemented in OlFlatStyleParser.