### PR TITLE
fix: update geostyler-libs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,17 @@
     "": {
       "name": "geostyler-cli",
       "dependencies": {
-        "geostyler-openlayers-parser": "^5.1.1",
+        "geostyler-lyrx-parser": "^1.2.0",
+        "geostyler-mapbox-parser": "^6.1.1",
+        "geostyler-mapfile-parser": "^4.0.1",
+        "geostyler-openlayers-parser": "^5.2.0",
+        "geostyler-qgis-parser": "^4.0.2",
+        "geostyler-sld-parser": "^8.1.0",
+        "geostyler-style": "^10.5.0",
+        "gradient-string": "^3.0.0",
+        "minimist": "^1.2.8",
+        "ol": "^10.5.0",
+        "ora": "8.2.0",
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -24,16 +34,6 @@
         "@typescript-eslint/parser": "^8.33.1",
         "adm-zip": "^0.5.16",
         "eslint": "^9.28.0",
-        "geostyler-lyrx-parser": "^1.1.3",
-        "geostyler-mapbox-parser": "^6.1.1",
-        "geostyler-mapfile-parser": "^4.0.1",
-        "geostyler-qgis-parser": "^4.0.2",
-        "geostyler-sld-parser": "^7.3.0",
-        "geostyler-style": "^10.1.0",
-        "gradient-string": "^3.0.0",
-        "minimist": "^1.2.8",
-        "ol": "^10.5.0",
-        "ora": "8.2.0",
         "pkg": "^5.8.1",
         "rimraf": "^6.0.1",
         "rollup": "^4.41.1",
@@ -593,7 +593,7 @@
 
     "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
 
-    "fast-xml-parser": ["fast-xml-parser@4.5.3", "", { "dependencies": { "strnum": "^1.1.1" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig=="],
+    "fast-xml-parser": ["fast-xml-parser@5.3.0", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -637,19 +637,19 @@
 
     "geostyler-cql-parser": ["geostyler-cql-parser@4.0.2", "", { "dependencies": { "geostyler-style": "^10.0.0" } }, "sha512-5vLbayLDTIb1OsURV2aZklbL7I7T4DTESuYoDD51Q+c39JX6ezv9CdtTFBRYPQmCEBCC85u5LXoCtLDl5MOxnw=="],
 
-    "geostyler-lyrx-parser": ["geostyler-lyrx-parser@1.1.3", "", { "dependencies": { "geostyler-style": "^10.0.0" } }, "sha512-Y8Sh5MJ3bYtouTPrS6dGhT2tfraukWGXaAVV1+kztS0BW+0YLwMGukuGHA87XudUugEO3kN+8awawVMFht+TtQ=="],
+    "geostyler-lyrx-parser": ["geostyler-lyrx-parser@1.2.0", "", { "dependencies": { "geostyler-style": "^10.3.0" } }, "sha512-hug3Y7q7lpwvm15BOsksNyj45dOa4+T/kP5jy1peznhOH/rAlyOMIKzO+PmfLdqhNoBY0I9dscPgCLGgds964Q=="],
 
     "geostyler-mapbox-parser": ["geostyler-mapbox-parser@6.1.1", "", { "dependencies": { "@types/mapbox-gl": "^2.7.18", "geostyler-style": "^10.0.0" } }, "sha512-2KUoCcYzMDc3wWcgQe4FhhKgMl8nrp3NWjECWGP+vlIfk7Hf5cKW4sQwr/la8LG1DHs/KILh+g4r03caKxSZbw=="],
 
     "geostyler-mapfile-parser": ["geostyler-mapfile-parser@4.0.1", "", { "dependencies": { "@terrestris/base-util": "^1.0.1", "geostyler-style": "9.1.0" } }, "sha512-6qiVXUi52QbOxgExeOeBh03LQLySiWSQ8VJyfZHTMUdzlAsVSLx+C9odyIBpkFS2gfzPtGgJRlmojbCHCGuBqQ=="],
 
-    "geostyler-openlayers-parser": ["geostyler-openlayers-parser@5.1.1", "", { "dependencies": { "css-font-parser": "^2.0.0", "geostyler-style": "^10.0.0", "lodash": "^4.17.21" }, "peerDependencies": { "ol": ">=7.4" } }, "sha512-obhJanQwyr8ciZg5kmqed7vunLiGofHn6+rve7pw70XZuQemJ5xr/5c5P5DwaYAyUT+vJquz1grvmDkGzB4oqg=="],
+    "geostyler-openlayers-parser": ["geostyler-openlayers-parser@5.2.0", "", { "dependencies": { "css-font-parser": "^2.0.0", "geostyler-style": "^10.3.0", "lodash": "^4.17.21" }, "peerDependencies": { "ol": ">=7.4" } }, "sha512-Ze3CcHnKyv82g//AbAZ63lDyRYWr+/FrBW/KRhzUdOJm9ylE2Irjf0dkNulIphu6ANIMO0eiyLrwJdH34iyogg=="],
 
     "geostyler-qgis-parser": ["geostyler-qgis-parser@4.0.2", "", { "dependencies": { "buffer": "^6.0.3", "color": "^4.2.3", "core-js": "^3.26.1", "geostyler-cql-parser": "^4.0.0", "geostyler-style": "^10.0.0", "string_decoder": "^1.3.0", "timers": "^0.1.1", "xml2js": "^0.6.0" } }, "sha512-rRLGMgvxlclpjGlQjgMIZ6VeMuXUqZK5VFF+vdDScM4Tg+pDBIfM0+jIIbTo7+vLhsgsTddxaVyNM4axJzHibA=="],
 
-    "geostyler-sld-parser": ["geostyler-sld-parser@7.3.0", "", { "dependencies": { "fast-xml-parser": "^4.4.1", "geostyler-style": "^10.0.0", "lodash": "^4.17.21" } }, "sha512-/D3F0UrxG8h561baoDWSeao7VMbra4V9X9sEYG3pHBRRz2SjBQ3S/VdRb8zBagXZ44TYupg4KZAv04aBF3BzFA=="],
+    "geostyler-sld-parser": ["geostyler-sld-parser@8.1.0", "", { "dependencies": { "fast-xml-parser": "^5.2.3", "geostyler-style": "^10.3.0", "lodash": "^4.17.21" } }, "sha512-9iDxWAR2nkkhMgBcAe+XgbmDdw36OdTEyGfXZcac5d7XbK8/KGZbxcKiQRiE9/+gPtFGIoc5+PSjjgWoJHMaaw=="],
 
-    "geostyler-style": ["geostyler-style@10.1.0", "", {}, "sha512-xJdF9OCXwK5Kec2B+WXrBWpIkb31+JKexb695M9wd3B20hPkRjaVM8L1G1S7TgpOMvqL/DPgohrOQXLxDCS9kw=="],
+    "geostyler-style": ["geostyler-style@10.5.0", "", {}, "sha512-XnKrjm5XY2hBc98h5uKaAdYAgy+R9YuBzf8aGo4SPmYoPtAlnNaGWkRZB8j/vnuzQg8/kpGVOJ94o+42WUhuhw=="],
 
     "geotiff": ["geotiff@2.1.3", "", { "dependencies": { "@petamoriken/float16": "^3.4.7", "lerc": "^3.0.0", "pako": "^2.0.4", "parse-headers": "^2.0.2", "quick-lru": "^6.1.1", "web-worker": "^1.2.0", "xml-utils": "^1.0.2", "zstddec": "^0.1.0" } }, "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA=="],
 
@@ -1141,7 +1141,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
+    "strnum": ["strnum@2.1.1", "", {}, "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="],
 
     "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
 
@@ -1425,7 +1425,13 @@
 
     "from2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "geostyler-cql-parser/geostyler-style": ["geostyler-style@10.1.0", "", {}, "sha512-xJdF9OCXwK5Kec2B+WXrBWpIkb31+JKexb695M9wd3B20hPkRjaVM8L1G1S7TgpOMvqL/DPgohrOQXLxDCS9kw=="],
+
+    "geostyler-mapbox-parser/geostyler-style": ["geostyler-style@10.1.0", "", {}, "sha512-xJdF9OCXwK5Kec2B+WXrBWpIkb31+JKexb695M9wd3B20hPkRjaVM8L1G1S7TgpOMvqL/DPgohrOQXLxDCS9kw=="],
+
     "geostyler-mapfile-parser/geostyler-style": ["geostyler-style@9.1.0", "", {}, "sha512-kExQDe2mf4YaVMZPKE7h2uxU5qSyAQoX2U2hLXyAWubJjeNoFe0nxt6rKn7C9Q1DE/9DVZopOdNLCXMtqOE6QA=="],
+
+    "geostyler-qgis-parser/geostyler-style": ["geostyler-style@10.1.0", "", {}, "sha512-xJdF9OCXwK5Kec2B+WXrBWpIkb31+JKexb695M9wd3B20hPkRjaVM8L1G1S7TgpOMvqL/DPgohrOQXLxDCS9kw=="],
 
     "git-log-parser/split2": ["split2@1.0.0", "", { "dependencies": { "through2": "~2.0.0" } }, "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg=="],
 

--- a/package.json
+++ b/package.json
@@ -69,16 +69,6 @@
     "@typescript-eslint/parser": "^8.33.1",
     "adm-zip": "^0.5.16",
     "eslint": "^9.28.0",
-    "geostyler-lyrx-parser": "^1.1.3",
-    "geostyler-mapbox-parser": "^6.1.1",
-    "geostyler-mapfile-parser": "^4.0.1",
-    "geostyler-qgis-parser": "^4.0.2",
-    "geostyler-sld-parser": "^7.3.0",
-    "geostyler-style": "^10.1.0",
-    "gradient-string": "^3.0.0",
-    "minimist": "^1.2.8",
-    "ol": "^10.5.0",
-    "ora": "8.2.0",
     "pkg": "^5.8.1",
     "rimraf": "^6.0.1",
     "rollup": "^4.41.1",
@@ -87,6 +77,16 @@
   },
   "funding": "https://opencollective.com/geostyler",
   "dependencies": {
-    "geostyler-openlayers-parser": "^5.1.1"
+    "geostyler-lyrx-parser": "^1.2.0",
+    "geostyler-mapbox-parser": "^6.1.1",
+    "geostyler-mapfile-parser": "^4.0.1",
+    "geostyler-openlayers-parser": "^5.2.0",
+    "geostyler-qgis-parser": "^4.0.2",
+    "geostyler-sld-parser": "^8.1.0",
+    "geostyler-style": "^10.5.0",
+    "gradient-string": "^3.0.0",
+    "ol": "^10.5.0",
+    "ora": "8.2.0",
+    "minimist": "^1.2.8"
   }
 }


### PR DESCRIPTION
This updates the geostyler-libs and moves dependencies from devDependencies to actual dependencies, where appropriate.