### PR TITLE
fix: reading mapbox styles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,8 +202,14 @@ async function writeFile(
       : await promises.readFile(sourceFile, 'utf-8');
 
     // If no sourceParser is set, just parse it as JSON - it should already be in geostyler format.
-    // LyrxParser expects a JSON object as input, so we need to parse it as an extra step.
-    if (!sourceParser || sourceParser instanceof LyrxParser || sourceParser instanceof OlFlatStyleParser) {
+    // LyrxParser, OlFlatStyleParser and MapboxParser expect a JSON object as input,
+    // so we need to parse it as an extra step.
+    if (
+      !sourceParser
+      || sourceParser instanceof LyrxParser
+      || sourceParser instanceof OlFlatStyleParser
+      || sourceParser instanceof MapboxParser
+    ) {
       inputFileData = JSON.parse(inputFileData);
     }
 

--- a/test.cjs
+++ b/test.cjs
@@ -105,6 +105,15 @@ function runAllTests() {
     success = false;
   }
 
+  // test mapbox style to geostyler
+  outputFile = 'output.json';
+  args = ['start', '--', '-s', 'mapbox', '-o', outputFile, 'testdata/point_simple.mapbox'];
+  runTest(args, outputFile);
+
+  if (checkFileCreated(outputFile) === false) {
+    success = false;
+  }
+
   // test folder output
   args = ['start', '--', '-s', 'sld', '-t', 'qgis', '-o', './output-bulk', 'testdata/sld'];
   runTest(args, outputFile);
@@ -152,10 +161,10 @@ function runAllTests() {
 
   // Test the parseOptions functions.
   if (!parseOptionsTest() || !parseEmptyOptionsTest()) {
-    console.log('Parser options tests failed');
+    console.log('\n\n\nParser options tests failed');
     success = false;
   } else {
-    console.log('Parser options tests ok');
+    console.log('\n\n\nParser options tests ok');
   }
 
   return success;

--- a/testdata/point_simple.mapbox
+++ b/testdata/point_simple.mapbox
@@ -1,0 +1,18 @@
+{
+  "version": 8,
+  "name": "Simple Point",
+  "layers": [
+    {
+      "type": "circle",
+      "paint": {
+        "circle-radius": 3,
+        "circle-color": "#FF0000",
+        "circle-opacity": 0.5,
+        "circle-stroke-color": "#0000FF",
+        "circle-stroke-opacity": 0.7
+      },
+      "id": "r0_sy0_st0"
+    }
+  ],
+  "sources": {}
+}


### PR DESCRIPTION
This fixes reading mapbox styles. We have to parse the mapbox style object first, before passing it to the parser.

solves https://github.com/geostyler/geostyler-cli/issues/461